### PR TITLE
Use `PublishSPAforGitHubPages.Build` to publish PWA via GitHub Pages

### DIFF
--- a/DnDCharCtor/DnDCharCtor.Pwa/DnDCharCtor.Pwa.csproj
+++ b/DnDCharCtor/DnDCharCtor.Pwa/DnDCharCtor.Pwa.csproj
@@ -20,6 +20,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.0" PrivateAssets="all" />
+	<!--https://github.com/jsakamoto/PublishSPAforGitHubPages.Build-->
+    <PackageReference Include="PublishSPAforGitHubPages.Build" Version="3.0.0" />
     <PackageReference Include="System.Text.Json" Version="9.0.0" />
   </ItemGroup>
 

--- a/DnDCharCtor/DnDCharCtor.Pwa/wwwroot/service-worker.published.js
+++ b/DnDCharCtor/DnDCharCtor.Pwa/wwwroot/service-worker.published.js
@@ -8,7 +8,8 @@ self.addEventListener('fetch', event => event.respondWith(onFetch(event)));
 
 const cacheNamePrefix = 'offline-cache-';
 const cacheName = `${cacheNamePrefix}${self.assetsManifest.version}`;
-const offlineAssetsInclude = [ /\.dll$/, /\.pdb$/, /\.wasm/, /\.html/, /\.js$/, /\.json$/, /\.css$/, /\.woff$/, /\.png$/, /\.jpe?g$/, /\.gif$/, /\.ico$/, /\.blat$/, /\.dat$/ ];
+// https://github.com/jsakamoto/PublishSPAforGitHubPages.Build
+const offlineAssetsInclude = [/\.dll$/, /\.pdb$/, /\.wasm/, /\.html/, /\.js$/, /\.json$/, /\.css$/, /\.woff$/, /\.png$/, /\.jpe?g$/, /\.gif$/, /\.ico$/, /\.blat$/, /\.dat$/, /\.br$/ ];
 const offlineAssetsExclude = [ /^service-worker\.js$/ ];
 
 // Replace with your base path if you are hosting on a subfolder. Ensure there is a trailing '/'.


### PR DESCRIPTION
Use `PublishSPAforGitHubPages.Build` to publish PWA via GitHub Pages.
`Action` must be updated to support this NuGet