### PR TITLE
Remove: Script that is intended for SSR (Static Server Rendering)

### DIFF
--- a/DnDCharCtor/DnDCharCtor.Maui/wwwroot/index.html
+++ b/DnDCharCtor/DnDCharCtor.Maui/wwwroot/index.html
@@ -33,7 +33,8 @@
     <!-- Set the default theme -->
     <script src="_content/Microsoft.FluentUI.AspNetCore.Components/js/loading-theme.js" type="text/javascript"></script>
     <loading-theme storage-name="theme"></loading-theme>
-    <script src="_content/Microsoft.FluentUI.AspNetCore.Components/Microsoft.FluentUI.AspNetCore.Components.lib.module.js" type="module" async></script>
+    <!--https://www.fluentui-blazor.net/CodeSetup-->
+    <!--<script src="_content/Microsoft.FluentUI.AspNetCore.Components/Microsoft.FluentUI.AspNetCore.Components.lib.module.js" type="module" async></script>-->
 
     <script src="_content/DnDCharCtor.Ui/scrollToInput.js"></script>
 </body>

--- a/DnDCharCtor/DnDCharCtor.Pwa/wwwroot/index.html
+++ b/DnDCharCtor/DnDCharCtor.Pwa/wwwroot/index.html
@@ -46,7 +46,8 @@
     <!-- Set the default theme -->
     <script src="_content/Microsoft.FluentUI.AspNetCore.Components/js/loading-theme.js" type="text/javascript"></script>
     <loading-theme storage-name="theme"></loading-theme>
-    <script src="_content/Microsoft.FluentUI.AspNetCore.Components/Microsoft.FluentUI.AspNetCore.Components.lib.module.js" type="module" async></script>
+    <!--https://www.fluentui-blazor.net/CodeSetup-->
+    <!--<script src="_content/Microsoft.FluentUI.AspNetCore.Components/Microsoft.FluentUI.AspNetCore.Components.lib.module.js" type="module" async></script>-->
 
     <script>navigator.serviceWorker.register('service-worker.js');</script>
 


### PR DESCRIPTION
From Docs:

Script
We wrap the Fluent UI Web Components, which are implemented in a script file, for quite a few of our components. This file is included in the library itself and does not have to be downloaded or pulled from a CDN.

By including the script in the library we can safeguard that you are always using the best matching script version.

In some cases, like when using .NET 8's new SSR (Static Server Rendering) rendermode, it might be necessary to include our library script in your App.razor manually. You can do so as follows:

<script src="_content/Microsoft.FluentUI.AspNetCore.Components/Microsoft.FluentUI.AspNetCore.Components.lib.module.js" type="module" async></script>
Copy
If you would later add interactivity, the Blazor script will kick in and try to load the web component script again but JavaScript will handle that gracefully by design.