### PR TITLE
Update: Disable Error-UI for Release

### DIFF
--- a/DnDCharCtor/DnDCharCtor.Pwa/Program.cs
+++ b/DnDCharCtor/DnDCharCtor.Pwa/Program.cs
@@ -18,3 +18,8 @@ builder.Services.RegisterAll();
 await WebAssemblyCultureProviderInterop.LoadSatelliteAssemblies(new string[] { Culture.EnglishCultureIdentifier, Culture.GermanCultureIdentifier, });
 
 await builder.Build().RunAsync();
+
+Console.WriteLine($"In the Logs you might see errors like 'Failed to fetch'{Environment.NewLine}" +
+    $"but these errors only occur when there is no internet connection.{Environment.NewLine}" +
+    $"This is NOT a problem, since the components are already loaded.{Environment.NewLine}" +
+    $"It only tries to load newer files.");

--- a/DnDCharCtor/DnDCharCtor.Pwa/wwwroot/index.html
+++ b/DnDCharCtor/DnDCharCtor.Pwa/wwwroot/index.html
@@ -31,13 +31,7 @@
         </svg>
         <div class="loading-progress-text"></div>
     </div>
-
-    <div id="blazor-error-ui">
-        An unhandled error has occurred.
-        <a href="." class="reload">Reload</a>
-        <span class="dismiss">🗙</span>
-    </div>
-
+    
     <!-- Set the default theme -->
     <script src="_content/Microsoft.FluentUI.AspNetCore.Components/js/loading-theme.js" type="text/javascript"></script>
     <loading-theme storage-name="theme"></loading-theme>

--- a/DnDCharCtor/DnDCharCtor.Ui/Layout/MainLayout.razor
+++ b/DnDCharCtor/DnDCharCtor.Ui/Layout/MainLayout.razor
@@ -21,4 +21,16 @@
             <FluentDialogProvider />
             <FluentTooltipProvider />
         </main>
-    </div>
+
+        @{
+            # if DEBUG   
+            {
+                <div id="blazor-error-ui">
+                    An unhandled error has occurred.
+                    <a href="." class="reload">Reload</a>
+                    <span class="dismiss">🗙</span>
+                </div>
+            }     
+            #endif
+        }
+</div>


### PR DESCRIPTION
In the Logs you might see errors like 'Failed to fetch'
but these errors only occur when there is no internet connection.
This is NOT a problem since the components are already loaded.
It only tries to load newer files.

Or that's why believe.
I think it has also something to do that the service worker loads the files as `Brotli` (but I cannot find where it saves these nor why the UI still works even if it seems that the FluentUI is not cached).