### PR TITLE
Bugfix/#6 fix has validation errors

### DIFF
--- a/DnDCharCtor.ViewModels/EditCharacterViewModel.cs
+++ b/DnDCharCtor.ViewModels/EditCharacterViewModel.cs
@@ -93,8 +93,8 @@ public partial class EditCharacterViewModel : ObservableValidator, IValidateable
 
     public bool HasUnsavedChanges()
     {
-        var chacater = CharacterViewModelToEdit.ToCharacter();
-        var hasChanges = chacater != Character.Empty;
+        var character = CharacterViewModelToEdit.ToCharacter();
+        var hasChanges = character != Character.Empty;
         var isUnsaved = IsSaved is false;
         return hasChanges && isUnsaved;
     }

--- a/DnDCharCtor.ViewModels/EditCharacterViewModel.cs
+++ b/DnDCharCtor.ViewModels/EditCharacterViewModel.cs
@@ -38,12 +38,6 @@ public partial class EditCharacterViewModel : ObservableValidator, IValidateable
     public EditMode EditMode { get; private set; } = EditMode.Create;
     public bool IsSaved { get; private set; } = false;
 
-    /// <summary>
-    /// This property is set to <see langword="true"/> 
-    /// when there are validation errors after calling the <see cref="Validate"/> method. 
-    /// We subscribe to the <see cref="ObservableValidator.ErrorsChanged"/> event to monitor changes in validation errors. 
-    /// This ensures that we only highlight validation errors when the user has finished editing and explicitly called <see cref="Validate"/>.
-    /// </summary>
     [ObservableProperty]
     private bool _hasValidationErrors;
     public Dictionary<string, IReadOnlyCollection<ValidationResult>> ValidationErrors { get; set; } = [];
@@ -95,12 +89,6 @@ public partial class EditCharacterViewModel : ObservableValidator, IValidateable
         HasValidationErrors = CharacterViewModelToEdit.Validate();
         ValidationErrors = CharacterViewModelToEdit.ValidationErrors;
 
-        if (HasValidationErrors) 
-        {
-            CharacterViewModelToEdit.ErrorsChanged -= CharacterViewModelToEdit_ErrorsChanged;
-            CharacterViewModelToEdit.ErrorsChanged += CharacterViewModelToEdit_ErrorsChanged; 
-        }
-
         return HasValidationErrors is false;
     }
 
@@ -128,7 +116,6 @@ public partial class EditCharacterViewModel : ObservableValidator, IValidateable
         GC.SuppressFinalize(this);
 
         _localizationService.PropertyChanged -= LocalizationService_OnPropertyChanged;
-        CharacterViewModelToEdit.ErrorsChanged -= CharacterViewModelToEdit_ErrorsChanged;
     }
 
 
@@ -136,22 +123,6 @@ public partial class EditCharacterViewModel : ObservableValidator, IValidateable
     private void LocalizationService_OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         UpdateTitle();
-    }
-
-    /// <summary>
-    /// This event handler is triggered when there are changes in validation errors. 
-    /// If there are no more validation errors (<see cref="ObservableValidator.HasErrors"/> is <see langword="false"/>), 
-    /// we set <see cref="HasValidationErrors"/> to <see langword="false"/> and unsubscribe from the <see cref="ObservableValidator.ErrorsChanged"/> event. 
-    /// This prevents the user from being constantly confronted with error borders during regular editing, 
-    /// reducing annoyance and improving the user experience.
-    /// </summary>
-    private void CharacterViewModelToEdit_ErrorsChanged(object? sender, DataErrorsChangedEventArgs e) 
-    { 
-        if (CharacterViewModelToEdit.HasErrors is false) 
-        { 
-            HasValidationErrors = false; 
-            CharacterViewModelToEdit.ErrorsChanged -= CharacterViewModelToEdit_ErrorsChanged; 
-        } 
     }
 }
 

--- a/DnDCharCtor.ViewModels/EditCharacterViewModel.cs
+++ b/DnDCharCtor.ViewModels/EditCharacterViewModel.cs
@@ -38,6 +38,12 @@ public partial class EditCharacterViewModel : ObservableValidator, IValidateable
     public EditMode EditMode { get; private set; } = EditMode.Create;
     public bool IsSaved { get; private set; } = false;
 
+    /// <summary>
+    /// This property is set to <see langword="true"/> 
+    /// when there are validation errors after calling the <see cref="Validate"/> method. 
+    /// We subscribe to the <see cref="ObservableValidator.ErrorsChanged"/> event to monitor changes in validation errors. 
+    /// This ensures that we only highlight validation errors when the user has finished editing and explicitly called <see cref="Validate"/>.
+    /// </summary>
     [ObservableProperty]
     private bool _hasValidationErrors;
     public Dictionary<string, IReadOnlyCollection<ValidationResult>> ValidationErrors { get; set; } = [];
@@ -88,6 +94,13 @@ public partial class EditCharacterViewModel : ObservableValidator, IValidateable
     {
         HasValidationErrors = CharacterViewModelToEdit.Validate();
         ValidationErrors = CharacterViewModelToEdit.ValidationErrors;
+
+        if (HasValidationErrors) 
+        {
+            CharacterViewModelToEdit.ErrorsChanged -= CharacterViewModelToEdit_ErrorsChanged;
+            CharacterViewModelToEdit.ErrorsChanged += CharacterViewModelToEdit_ErrorsChanged; 
+        }
+
         return HasValidationErrors is false;
     }
 
@@ -115,6 +128,7 @@ public partial class EditCharacterViewModel : ObservableValidator, IValidateable
         GC.SuppressFinalize(this);
 
         _localizationService.PropertyChanged -= LocalizationService_OnPropertyChanged;
+        CharacterViewModelToEdit.ErrorsChanged -= CharacterViewModelToEdit_ErrorsChanged;
     }
 
 
@@ -122,6 +136,22 @@ public partial class EditCharacterViewModel : ObservableValidator, IValidateable
     private void LocalizationService_OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         UpdateTitle();
+    }
+
+    /// <summary>
+    /// This event handler is triggered when there are changes in validation errors. 
+    /// If there are no more validation errors (<see cref="ObservableValidator.HasErrors"/> is <see langword="false"/>), 
+    /// we set <see cref="HasValidationErrors"/> to <see langword="false"/> and unsubscribe from the <see cref="ObservableValidator.ErrorsChanged"/> event. 
+    /// This prevents the user from being constantly confronted with error borders during regular editing, 
+    /// reducing annoyance and improving the user experience.
+    /// </summary>
+    private void CharacterViewModelToEdit_ErrorsChanged(object? sender, DataErrorsChangedEventArgs e) 
+    { 
+        if (CharacterViewModelToEdit.HasErrors is false) 
+        { 
+            HasValidationErrors = false; 
+            CharacterViewModelToEdit.ErrorsChanged -= CharacterViewModelToEdit_ErrorsChanged; 
+        } 
     }
 }
 

--- a/DnDCharCtor.ViewModels/MainViewModel.cs
+++ b/DnDCharCtor.ViewModels/MainViewModel.cs
@@ -36,10 +36,12 @@ public partial class MainViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     private bool _isBusy;
 
-    private readonly TaskCompletionSource<bool> _initializationTcs = new();
-    public Task InitializationTask => _initializationTcs.Task;
+    private TaskCompletionSource<bool> _initializationTcs = new();
+    public Task<bool> InitializationTask => _initializationTcs.Task;
     public async Task<bool> InitializeAsync()
     {
+        _initializationTcs = new();
+
         IsBusy = true;
         var selectedLanguage = await _hybridCacheService.GetSelectedLanguageAsync();
         _localizationService.ChangeCulture(selectedLanguage);
@@ -47,7 +49,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
         await ReloadCurrentCharacterAsync(true);
         
         IsBusy = false;
-        return true;
+
+        _initializationTcs.SetResult(true);
+        return await _initializationTcs.Task;
     }
 
     public async Task<bool> ReloadCurrentCharacterAsync(bool ignoreIsBusy = false)
@@ -57,8 +61,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
         CurrentCharacterViewModel = new(currentCharacter ?? Character.Empty);
         if (ignoreIsBusy) IsBusy = false;
 
-        _initializationTcs.SetResult(true);
-        return await _initializationTcs.Task;
+        return true;
     }
 
 

--- a/DnDCharCtor/DnDCharCtor.Ui/Components/Cards/PersonalityCard.razor.cs
+++ b/DnDCharCtor/DnDCharCtor.Ui/Components/Cards/PersonalityCard.razor.cs
@@ -39,6 +39,12 @@ public partial class PersonalityCard
         if (result.Cancelled is false && result.Data is not null)
         {
             ViewModel = (PersonalityViewModel)result.Data;
+            // When we started Editing with Validation-Errors (because the user tried to Save before):
+            // we want to re-validate after submit to set `HasValidationErrors` to false when all errors were resolved.
+            if (ViewModel.HasValidationErrors)
+            {
+                ViewModel.Validate();
+            }
             await ViewModelChanged.InvokeAsync(ViewModel);
             StateHasChanged();
         }

--- a/DnDCharCtor/DnDCharCtor.Ui/Components/Dialogs/EditPersonalityDialog.razor.cs
+++ b/DnDCharCtor/DnDCharCtor.Ui/Components/Dialogs/EditPersonalityDialog.razor.cs
@@ -16,9 +16,4 @@ public partial class EditPersonalityDialog
 
     [Parameter]
     public PersonalityViewModel Content { get; set; } = default!;
-
-    private async Task HandleFocus()
-    {
-        await JSRuntime.InvokeVoidAsync("scrollToInput");
-    }
 }


### PR DESCRIPTION
Update: Re-`Validate` `IValidateableViewModel` when `HasValidationErrors` was true before Re-Editing

Comment: This way the card only gets a red border when the user tried to save. The red border will stay until user submits (which causes re-validation)

ToDo: Currently, there is no concept what we do when we have Navigation in Popups but this is a future problem