### PR TITLE
Add: `Finalizer` to classes that implement `IDispose`;

### DIFF
--- a/DnDCharCtor.ViewModels/EditCharacterViewModel.cs
+++ b/DnDCharCtor.ViewModels/EditCharacterViewModel.cs
@@ -111,6 +111,8 @@ public partial class EditCharacterViewModel : ObservableValidator, IValidateable
 
 
 
+    ~EditCharacterViewModel() => Dispose();
+
     public void Dispose()
     {
         GC.SuppressFinalize(this);

--- a/DnDCharCtor.ViewModels/MainViewModel.cs
+++ b/DnDCharCtor.ViewModels/MainViewModel.cs
@@ -80,6 +80,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
 
 
+    ~MainViewModel() => Dispose();
+
     public void Dispose()
     {
         GC.SuppressFinalize(this);

--- a/DnDCharCtor/DnDCharCtor.Maui/Services/DatabaseService.cs
+++ b/DnDCharCtor/DnDCharCtor.Maui/Services/DatabaseService.cs
@@ -44,6 +44,8 @@ internal class DatabaseService : IDisposable, IDatabaseService
     }
 
 
+    ~DatabaseService() => Dispose();
+
     public void Dispose()
     {
         GC.SuppressFinalize(this);


### PR DESCRIPTION
Comment: Our `Pages` do not need a `Finalizer` since Blazor calls the `Dispose`-Method (unlike XAML-Pages where you must register to the `Unload`-Event and then call `Dispose` during `Unload`. Also Note that Blazor itself currently has nothing like `Unload`.

Closes #7 