### PR TITLE
Update: `Personality`.`Background` to use a `FluentTextField`

### DIFF
--- a/DnDCharCtor/DnDCharCtor.Ui/Components/Dialogs/EditPersonalityDialog.razor
+++ b/DnDCharCtor/DnDCharCtor.Ui/Components/Dialogs/EditPersonalityDialog.razor
@@ -37,7 +37,7 @@
     <ValidationMessage For="@(() => Content.ViewModel.Level)" />
     <br />
 
-    <FluentTextArea @bind-Value="Content.ViewModel.Background" Label="@StringResources.Character_Personality_Background" Immediate="true" />
+    <FluentTextField @bind-Value="Content.ViewModel.Background" Label="@StringResources.Character_Personality_Background" Immediate="true" />
     <ValidationMessage For="@(() => Content.ViewModel.Background)" />
     <br />
 


### PR DESCRIPTION
Update: Personality.Background to use a FluentTextField instead of a `FluentTextArea` since it does NOT contain a background-story