### PR TITLE
Feature/#67 cards do not match rules

### DIFF
--- a/DnDCharCtor.Common/Extensions/StringExtensions.cs
+++ b/DnDCharCtor.Common/Extensions/StringExtensions.cs
@@ -1,0 +1,14 @@
+namespace DnDCharCtor.Common.Extensions;
+
+public static class StringExtensions
+{
+    public static int? ToInt(this string value)
+    {
+        if (int.TryParse(value, out int result))
+        {
+            return result;
+        }
+        return null;
+    }
+}
+

--- a/DnDCharCtor.Common/Services/DndRulesService.cs
+++ b/DnDCharCtor.Common/Services/DndRulesService.cs
@@ -1,0 +1,9 @@
+namespace DnDCharCtor.Common.Services;
+
+public class DndRulesService : IDndRulesService
+{
+    public int CalculateStatModifier(int abilityScore)
+    {
+        return (abilityScore - 10) / 2;
+    }
+}

--- a/DnDCharCtor.Common/Services/IDndRulesService.cs
+++ b/DnDCharCtor.Common/Services/IDndRulesService.cs
@@ -1,0 +1,6 @@
+namespace DnDCharCtor.Common.Services;
+
+public interface IDndRulesService
+{
+    int CalculateStatModifier(int abilityScore);
+}

--- a/DnDCharCtor.Resources/StringResources.Designer.cs
+++ b/DnDCharCtor.Resources/StringResources.Designer.cs
@@ -853,6 +853,15 @@ namespace DnDCharCtor.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to ~Stat Modifier.
+        /// </summary>
+        public static string Stat_Modifier {
+            get {
+                return ResourceManager.GetString("Stat_Modifier", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ~Cannot save since some cards and fields have validation errors.
         /// </summary>
         public static string Validation_CannotSave {

--- a/DnDCharCtor.Resources/StringResources.de-DE.resx
+++ b/DnDCharCtor.Resources/StringResources.de-DE.resx
@@ -405,4 +405,7 @@
   <data name="CharacterEditor_Skills_Edit" xml:space="preserve">
     <value>Bearbeite Fertigkeiten</value>
   </data>
+  <data name="Stat_Modifier" xml:space="preserve">
+    <value>Status-Modifikator</value>
+  </data>
 </root>

--- a/DnDCharCtor.Resources/StringResources.en-US.resx
+++ b/DnDCharCtor.Resources/StringResources.en-US.resx
@@ -405,4 +405,7 @@
   <data name="CharacterEditor_Skills_Edit" xml:space="preserve">
     <value>Edit skills</value>
   </data>
+  <data name="Stat_Modifier" xml:space="preserve">
+    <value>Stat Modifier</value>
+  </data>
 </root>

--- a/DnDCharCtor.Resources/StringResources.resx
+++ b/DnDCharCtor.Resources/StringResources.resx
@@ -405,4 +405,7 @@
   <data name="CharacterEditor_Skills_Edit" xml:space="preserve">
     <value>~Edit skills</value>
   </data>
+  <data name="Stat_Modifier" xml:space="preserve">
+    <value>~Stat Modifier</value>
+  </data>
 </root>

--- a/DnDCharCtor.ViewModels/ModelViewModels/PropertiesViewModel.cs
+++ b/DnDCharCtor.ViewModels/ModelViewModels/PropertiesViewModel.cs
@@ -47,55 +47,55 @@ public partial class PropertiesViewModel : ObservableValidator, IViewModelBase<P
     [ObservableProperty]
     [NotifyDataErrorInfo]
     [LocalizedParsedIntegerRequired(nameof(StringResources.Character_Strength))]
-    [LocalizedParsedRange(nameof(StringResources.Character_Strength), 1, int.MaxValue)]
+    [LocalizedParsedRange(nameof(StringResources.Character_Strength), 1, 30)]
     private string _strength;
 
     [ObservableProperty]
     [NotifyDataErrorInfo]
     [LocalizedParsedIntegerRequired(nameof(StringResources.Character_Skillfulness))]
-    [LocalizedParsedRange(nameof(StringResources.Character_Skillfulness), 1, int.MaxValue)]
+    [LocalizedParsedRange(nameof(StringResources.Character_Skillfulness), 1, 30)]
     private string _skillfulness;
 
     [ObservableProperty]
     [NotifyDataErrorInfo]
     [LocalizedParsedIntegerRequired(nameof(StringResources.Character_Constitution))]
-    [LocalizedParsedRange(nameof(StringResources.Character_Constitution), 1, int.MaxValue)]
+    [LocalizedParsedRange(nameof(StringResources.Character_Constitution), 1, 30)]
     private string _constitution;
 
     [ObservableProperty]
     [NotifyDataErrorInfo]
     [LocalizedParsedIntegerRequired(nameof(StringResources.Character_Intelligence))]
-    [LocalizedParsedRange(nameof(StringResources.Character_Intelligence), 1, int.MaxValue)]
+    [LocalizedParsedRange(nameof(StringResources.Character_Intelligence), 1, 30)]
     private string _intelligence;
 
     [ObservableProperty]
     [NotifyDataErrorInfo]
     [LocalizedParsedIntegerRequired(nameof(StringResources.Character_Wisdom))]
-    [LocalizedParsedRange(nameof(StringResources.Character_Wisdom), 1, int.MaxValue)]
+    [LocalizedParsedRange(nameof(StringResources.Character_Wisdom), 1, 30)]
     private string _wisdom;
 
     [ObservableProperty]
     [NotifyDataErrorInfo]
     [LocalizedParsedIntegerRequired(nameof(StringResources.Character_Charisma))]
-    [LocalizedParsedRange(nameof(StringResources.Character_Charisma), 1, int.MaxValue)]
+    [LocalizedParsedRange(nameof(StringResources.Character_Charisma), 1, 30)]
     private string _charisma;
 
     [ObservableProperty]
     [NotifyDataErrorInfo]
     [LocalizedParsedIntegerRequired(nameof(StringResources.Character_Inspiration))]
-    [LocalizedParsedRange(nameof(StringResources.Character_Inspiration), 1, int.MaxValue)]
+    [LocalizedParsedRange(nameof(StringResources.Character_Inspiration), 1, 30)]
     private string _inspiration;
 
     [ObservableProperty]
     [NotifyDataErrorInfo]
     [LocalizedParsedIntegerRequired(nameof(StringResources.Character_TrainingBonus))]
-    [LocalizedParsedRange(nameof(StringResources.Character_TrainingBonus), 1, int.MaxValue)]
+    [LocalizedParsedRange(nameof(StringResources.Character_TrainingBonus), 1, 30)]
     private string _trainingBonus;
 
     [ObservableProperty]
     [NotifyDataErrorInfo]
     [LocalizedParsedIntegerRequired(nameof(StringResources.Character_PassiveWisdomRecognition))]
-    [LocalizedParsedRange(nameof(StringResources.Character_PassiveWisdomRecognition), 1, int.MaxValue)]
+    [LocalizedParsedRange(nameof(StringResources.Character_PassiveWisdomRecognition), 1, 30)]
     private string _passiveWisdomRecognition;
 
 

--- a/DnDCharCtor/DnDCharCtor.Ui/Components/Cards/PropertiesCard.razor
+++ b/DnDCharCtor/DnDCharCtor.Ui/Components/Cards/PropertiesCard.razor
@@ -3,16 +3,22 @@
 <EditableCardBase Title="@StringResources.Character_Properties" EditButtonText="@EditButtonText" EditButtonIcon="@EditButtonIcon" EditButtonCallback="EditAsync" CardClickCallback="EditAsync" HasValidationErrors="@(ViewModel.HasValidationErrors)">
     <br />
     <div><strong>@StringResources.Character_Strength:</strong> @ViewModel.Strength </div>
+    <div><strong>@StringResources.Character_Strength (@StringResources.Stat_Modifier):</strong> @(ViewModel.Strength.ToInt()) </div>
     <br />
     <div><strong>@StringResources.Character_Skillfulness:</strong> @ViewModel.Skillfulness </div>
+    <div><strong>@StringResources.Character_Skillfulness (@StringResources.Stat_Modifier):</strong> @(ViewModel.Skillfulness.ToInt()) </div>
     <br />
     <div><strong>@StringResources.Character_Constitution:</strong> @ViewModel.Constitution </div>
+    <div><strong>@StringResources.Character_Constitution (@StringResources.Stat_Modifier):</strong> @(ViewModel.Constitution.ToInt()) </div>
     <br />
     <div><strong>@StringResources.Character_Intelligence:</strong> @ViewModel.Intelligence </div>
+    <div><strong>@StringResources.Character_Intelligence (@StringResources.Stat_Modifier):</strong> @(ViewModel.Intelligence.ToInt()) </div>
     <br />
     <div><strong>@StringResources.Character_Wisdom:</strong> @ViewModel.Wisdom </div>
+    <div><strong>@StringResources.Character_Wisdom (@StringResources.Stat_Modifier):</strong> @(ViewModel.Wisdom.ToInt()) </div>
     <br />
     <div><strong>@StringResources.Character_Charisma:</strong> @ViewModel.Charisma </div>
+    <div><strong>@StringResources.Character_Charisma (@StringResources.Stat_Modifier):</strong> @(ViewModel.Charisma.ToInt()) </div>
     <br />
     <div><strong>@StringResources.Character_Inspiration:</strong> @ViewModel.Inspiration </div>
     <br />
@@ -20,5 +26,3 @@
     <br />
     <div><strong>@StringResources.Character_PassiveWisdomRecognition:</strong> @ViewModel.PassiveWisdomRecognition </div>
 </EditableCardBase>
-
-

--- a/DnDCharCtor/DnDCharCtor.Ui/Components/Cards/PropertiesCard.razor
+++ b/DnDCharCtor/DnDCharCtor.Ui/Components/Cards/PropertiesCard.razor
@@ -3,22 +3,22 @@
 <EditableCardBase Title="@StringResources.Character_Properties" EditButtonText="@EditButtonText" EditButtonIcon="@EditButtonIcon" EditButtonCallback="EditAsync" CardClickCallback="EditAsync" HasValidationErrors="@(ViewModel.HasValidationErrors)">
     <br />
     <div><strong>@StringResources.Character_Strength:</strong> @ViewModel.Strength </div>
-    <div><strong>@StringResources.Character_Strength (@StringResources.Stat_Modifier):</strong> @(ViewModel.Strength.ToInt()) </div>
+    <div><strong>@StringResources.Character_Strength (@StringResources.Stat_Modifier):</strong> @(ViewModel.Strength.ToInt() is int strength ? DndRulesService.CalculateStatModifier(strength) : string.Empty) </div>
     <br />
     <div><strong>@StringResources.Character_Skillfulness:</strong> @ViewModel.Skillfulness </div>
-    <div><strong>@StringResources.Character_Skillfulness (@StringResources.Stat_Modifier):</strong> @(ViewModel.Skillfulness.ToInt()) </div>
+    <div><strong>@StringResources.Character_Skillfulness (@StringResources.Stat_Modifier):</strong> @(ViewModel.Skillfulness.ToInt() is int skillfulness ? DndRulesService.CalculateStatModifier(skillfulness) : string.Empty) </div>
     <br />
     <div><strong>@StringResources.Character_Constitution:</strong> @ViewModel.Constitution </div>
-    <div><strong>@StringResources.Character_Constitution (@StringResources.Stat_Modifier):</strong> @(ViewModel.Constitution.ToInt()) </div>
+    <div><strong>@StringResources.Character_Constitution (@StringResources.Stat_Modifier):</strong> @(ViewModel.Constitution.ToInt() is int constitution ? DndRulesService.CalculateStatModifier(constitution) : string.Empty) </div>
     <br />
     <div><strong>@StringResources.Character_Intelligence:</strong> @ViewModel.Intelligence </div>
-    <div><strong>@StringResources.Character_Intelligence (@StringResources.Stat_Modifier):</strong> @(ViewModel.Intelligence.ToInt()) </div>
+    <div><strong>@StringResources.Character_Intelligence (@StringResources.Stat_Modifier):</strong> @(ViewModel.Intelligence.ToInt() is int intelligence ? DndRulesService.CalculateStatModifier(intelligence) : string.Empty) </div>
     <br />
     <div><strong>@StringResources.Character_Wisdom:</strong> @ViewModel.Wisdom </div>
-    <div><strong>@StringResources.Character_Wisdom (@StringResources.Stat_Modifier):</strong> @(ViewModel.Wisdom.ToInt()) </div>
+    <div><strong>@StringResources.Character_Wisdom (@StringResources.Stat_Modifier):</strong> @(ViewModel.Wisdom.ToInt() is int wisdom ? DndRulesService.CalculateStatModifier(wisdom) : string.Empty) </div>
     <br />
     <div><strong>@StringResources.Character_Charisma:</strong> @ViewModel.Charisma </div>
-    <div><strong>@StringResources.Character_Charisma (@StringResources.Stat_Modifier):</strong> @(ViewModel.Charisma.ToInt()) </div>
+    <div><strong>@StringResources.Character_Charisma (@StringResources.Stat_Modifier):</strong> @(ViewModel.Charisma.ToInt() is int charisma ? DndRulesService.CalculateStatModifier(charisma) : string.Empty) </div>
     <br />
     <div><strong>@StringResources.Character_Inspiration:</strong> @ViewModel.Inspiration </div>
     <br />

--- a/DnDCharCtor/DnDCharCtor.Ui/Components/Cards/PropertiesCard.razor.cs
+++ b/DnDCharCtor/DnDCharCtor.Ui/Components/Cards/PropertiesCard.razor.cs
@@ -1,3 +1,4 @@
+using DnDCharCtor.Common.Services;
 using DnDCharCtor.Resources;
 using DnDCharCtor.Ui.Components.Dialogs;
 using DnDCharCtor.ViewModels.ModelViewModels;
@@ -8,5 +9,8 @@ namespace DnDCharCtor.Ui.Components.Cards;
 
 public partial class PropertiesCard : EditableCardAbstraction<PropertiesViewModel, EditPropertiesDialog>
 {
+    [Inject]
+    public IDndRulesService DndRulesService { get; set; } = default!;
+
     public override string DialogTitle => StringResources.CharacterEditor_Properties_Edit;
 }

--- a/DnDCharCtor/DnDCharCtor.Ui/Components/Dialogs/EditPropertiesDialog.razor
+++ b/DnDCharCtor/DnDCharCtor.Ui/Components/Dialogs/EditPropertiesDialog.razor
@@ -3,32 +3,32 @@
 <EditDialogBase Content="@Content">
     <FluentTextField InputMode="InputMode.Numeric" @bind-Value="Content.ViewModel.Strength" Label="@StringResources.Character_Strength" Immediate="true" Required="true" title="@StringResources.Validation_Tooltip_Required" />
     <ValidationMessage For="@(() => Content.ViewModel.Strength)" />
-    <div><strong>@StringResources.Character_Strength (@StringResources.Stat_Modifier):</strong> @(Content.ViewModel.Strength.ToInt()) </div>
+    <div>@StringResources.Character_Strength (@StringResources.Stat_Modifier): @(Content.ViewModel.Strength.ToInt() is int strength ? DndRulesService.CalculateStatModifier(strength) : string.Empty) </div>
     <br />
 
     <FluentTextField InputMode="InputMode.Numeric" @bind-Value="Content.ViewModel.Skillfulness" Label="@StringResources.Character_Skillfulness" Immediate="true" Required="true" title="@StringResources.Validation_Tooltip_Required" />
     <ValidationMessage For="@(() => Content.ViewModel.Skillfulness)" />
-    <div><strong>@StringResources.Character_Skillfulness (@StringResources.Stat_Modifier):</strong> @(Content.ViewModel.Skillfulness.ToInt()) </div>
+    <div>@StringResources.Character_Skillfulness (@StringResources.Stat_Modifier): @(Content.ViewModel.Skillfulness.ToInt() is int skillfulness ? DndRulesService.CalculateStatModifier(skillfulness) : string.Empty) </div>
     <br />
 
     <FluentTextField InputMode="InputMode.Numeric" @bind-Value="Content.ViewModel.Constitution" Label="@StringResources.Character_Constitution" Immediate="true" Required="true" title="@StringResources.Validation_Tooltip_Required" />
     <ValidationMessage For="@(() => Content.ViewModel.Constitution)" />
-    <div><strong>@StringResources.Character_Constitution (@StringResources.Stat_Modifier):</strong> @(Content.ViewModel.Constitution.ToInt()) </div>
+    <div>@StringResources.Character_Constitution (@StringResources.Stat_Modifier): @(Content.ViewModel.Constitution.ToInt() is int constitution ? DndRulesService.CalculateStatModifier(constitution) : string.Empty) </div>
     <br />
 
     <FluentTextField InputMode="InputMode.Numeric" @bind-Value="Content.ViewModel.Intelligence" Label="@StringResources.Character_Intelligence" Immediate="true" Required="true" title="@StringResources.Validation_Tooltip_Required" />
     <ValidationMessage For="@(() => Content.ViewModel.Intelligence)" />
-    <div><strong>@StringResources.Character_Intelligence (@StringResources.Stat_Modifier):</strong> @(Content.ViewModel.Intelligence.ToInt()) </div>
+    <div>@StringResources.Character_Intelligence (@StringResources.Stat_Modifier): @(Content.ViewModel.Intelligence.ToInt() is int intelligence ? DndRulesService.CalculateStatModifier(intelligence) : string.Empty) </div>
     <br />
 
     <FluentTextField InputMode="InputMode.Numeric" @bind-Value="Content.ViewModel.Wisdom" Label="@StringResources.Character_Wisdom" Immediate="true" Required="true" title="@StringResources.Validation_Tooltip_Required" />
     <ValidationMessage For="@(() => Content.ViewModel.Wisdom)" />
-    <div><strong>@StringResources.Character_Wisdom (@StringResources.Stat_Modifier):</strong> @(Content.ViewModel.Wisdom.ToInt()) </div>
+    <div>@StringResources.Character_Wisdom (@StringResources.Stat_Modifier): @(Content.ViewModel.Wisdom.ToInt() is int wisdom ? DndRulesService.CalculateStatModifier(wisdom) : string.Empty) </div>
     <br />
 
     <FluentTextField InputMode="InputMode.Numeric" @bind-Value="Content.ViewModel.Charisma" Label="@StringResources.Character_Charisma" Immediate="true" Required="true" title="@StringResources.Validation_Tooltip_Required" />
     <ValidationMessage For="@(() => Content.ViewModel.Charisma)" />
-    <div><strong>@StringResources.Character_Charisma (@StringResources.Stat_Modifier):</strong> @(Content.ViewModel.Charisma.ToInt()) </div>
+    <div>@StringResources.Character_Charisma (@StringResources.Stat_Modifier): @(Content.ViewModel.Charisma.ToInt() is int charisma ? DndRulesService.CalculateStatModifier(charisma) : string.Empty) </div>
     <br />
 
     <FluentTextField InputMode="InputMode.Numeric" @bind-Value="Content.ViewModel.Inspiration" Label="@StringResources.Character_Inspiration" Immediate="true" Required="true" title="@StringResources.Validation_Tooltip_Required" />
@@ -42,4 +42,3 @@
     <FluentTextField InputMode="InputMode.Numeric" @bind-Value="Content.ViewModel.PassiveWisdomRecognition" Label="@StringResources.Character_PassiveWisdomRecognition" Immediate="true" Required="true" title="@StringResources.Validation_Tooltip_Required" />
     <ValidationMessage For="@(() => Content.ViewModel.PassiveWisdomRecognition)" />
 </EditDialogBase>
-

--- a/DnDCharCtor/DnDCharCtor.Ui/Components/Dialogs/EditPropertiesDialog.razor
+++ b/DnDCharCtor/DnDCharCtor.Ui/Components/Dialogs/EditPropertiesDialog.razor
@@ -3,26 +3,32 @@
 <EditDialogBase Content="@Content">
     <FluentTextField InputMode="InputMode.Numeric" @bind-Value="Content.ViewModel.Strength" Label="@StringResources.Character_Strength" Immediate="true" Required="true" title="@StringResources.Validation_Tooltip_Required" />
     <ValidationMessage For="@(() => Content.ViewModel.Strength)" />
+    <div><strong>@StringResources.Character_Strength (@StringResources.Stat_Modifier):</strong> @(Content.ViewModel.Strength.ToInt()) </div>
     <br />
 
     <FluentTextField InputMode="InputMode.Numeric" @bind-Value="Content.ViewModel.Skillfulness" Label="@StringResources.Character_Skillfulness" Immediate="true" Required="true" title="@StringResources.Validation_Tooltip_Required" />
     <ValidationMessage For="@(() => Content.ViewModel.Skillfulness)" />
+    <div><strong>@StringResources.Character_Skillfulness (@StringResources.Stat_Modifier):</strong> @(Content.ViewModel.Skillfulness.ToInt()) </div>
     <br />
 
     <FluentTextField InputMode="InputMode.Numeric" @bind-Value="Content.ViewModel.Constitution" Label="@StringResources.Character_Constitution" Immediate="true" Required="true" title="@StringResources.Validation_Tooltip_Required" />
     <ValidationMessage For="@(() => Content.ViewModel.Constitution)" />
+    <div><strong>@StringResources.Character_Constitution (@StringResources.Stat_Modifier):</strong> @(Content.ViewModel.Constitution.ToInt()) </div>
     <br />
 
     <FluentTextField InputMode="InputMode.Numeric" @bind-Value="Content.ViewModel.Intelligence" Label="@StringResources.Character_Intelligence" Immediate="true" Required="true" title="@StringResources.Validation_Tooltip_Required" />
     <ValidationMessage For="@(() => Content.ViewModel.Intelligence)" />
+    <div><strong>@StringResources.Character_Intelligence (@StringResources.Stat_Modifier):</strong> @(Content.ViewModel.Intelligence.ToInt()) </div>
     <br />
 
     <FluentTextField InputMode="InputMode.Numeric" @bind-Value="Content.ViewModel.Wisdom" Label="@StringResources.Character_Wisdom" Immediate="true" Required="true" title="@StringResources.Validation_Tooltip_Required" />
     <ValidationMessage For="@(() => Content.ViewModel.Wisdom)" />
+    <div><strong>@StringResources.Character_Wisdom (@StringResources.Stat_Modifier):</strong> @(Content.ViewModel.Wisdom.ToInt()) </div>
     <br />
 
     <FluentTextField InputMode="InputMode.Numeric" @bind-Value="Content.ViewModel.Charisma" Label="@StringResources.Character_Charisma" Immediate="true" Required="true" title="@StringResources.Validation_Tooltip_Required" />
     <ValidationMessage For="@(() => Content.ViewModel.Charisma)" />
+    <div><strong>@StringResources.Character_Charisma (@StringResources.Stat_Modifier):</strong> @(Content.ViewModel.Charisma.ToInt()) </div>
     <br />
 
     <FluentTextField InputMode="InputMode.Numeric" @bind-Value="Content.ViewModel.Inspiration" Label="@StringResources.Character_Inspiration" Immediate="true" Required="true" title="@StringResources.Validation_Tooltip_Required" />
@@ -36,3 +42,4 @@
     <FluentTextField InputMode="InputMode.Numeric" @bind-Value="Content.ViewModel.PassiveWisdomRecognition" Label="@StringResources.Character_PassiveWisdomRecognition" Immediate="true" Required="true" title="@StringResources.Validation_Tooltip_Required" />
     <ValidationMessage For="@(() => Content.ViewModel.PassiveWisdomRecognition)" />
 </EditDialogBase>
+

--- a/DnDCharCtor/DnDCharCtor.Ui/Components/Dialogs/EditPropertiesDialog.razor.cs
+++ b/DnDCharCtor/DnDCharCtor.Ui/Components/Dialogs/EditPropertiesDialog.razor.cs
@@ -1,3 +1,4 @@
+using DnDCharCtor.Common.Services;
 using DnDCharCtor.ViewModels.ModelViewModels;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
@@ -11,4 +12,7 @@ public partial class EditPropertiesDialog
 
     [Parameter]
     public EditDialogParameter<PropertiesViewModel> Content { get; set; } = default!;
+
+    [Inject]
+    public IDndRulesService DndRulesService { get; set; } = default!;
 }

--- a/DnDCharCtor/DnDCharCtor.Ui/ServiceRegister.cs
+++ b/DnDCharCtor/DnDCharCtor.Ui/ServiceRegister.cs
@@ -30,6 +30,7 @@ public static class ServiceRegister
         services.AddSingleton<ILocalizationService, LocalizationService>();
         services.AddSingleton<IHybridCacheService, HybridCacheService>();
         services.AddSingleton<IEventAggregator, EventAggregator>();
+        services.AddSingleton<IDndRulesService, DndRulesService>();
 
         return services;
     }

--- a/DnDCharCtor/DnDCharCtor.Ui/_Imports.razor
+++ b/DnDCharCtor/DnDCharCtor.Ui/_Imports.razor
@@ -19,6 +19,7 @@
 @using Microsoft.FluentUI.AspNetCore.Components.Extensions
 
 @using DnDCharCtor.Common.Constants
+@using DnDCharCtor.Common.Extensions
 @using DnDCharCtor.Common.Services
 @using DnDCharCtor.Resources
 @using DnDCharCtor.Models


### PR DESCRIPTION
Updated validation attributes and added stat modifier display

- Updated validation attributes in PropertiesViewModel.cs to use appropriate ranges for D&D ability scores (1-30).
- Created StringExtensions class with ToInt extension method to convert string to integer.
- Updated PropertiesCard.razor to display stat modifiers for character properties using DndRulesService.
- Updated EditPropertiesDialog.razor to display stat modifiers for character properties using DndRulesService.
- Added Stat_Modifier string resource to StringResources.resx, StringResources.en-US.resx, and StringResources.de-DE.resx.
- Registered IDndRulesService and DndRulesService in ServiceRegister.cs.
