### PR TITLE
Feature/#67 cards do not match rules

### DIFF
--- a/DnDCharCtor.Common/Services/DndRulesService.cs
+++ b/DnDCharCtor.Common/Services/DndRulesService.cs
@@ -4,6 +4,8 @@ public class DndRulesService : IDndRulesService
 {
     public int CalculateStatModifier(int abilityScore)
     {
+        if (abilityScore < 1) return 0;
+
         return (abilityScore - 10) / 2;
     }
 }

--- a/DnDCharCtor.Resources/StringResources.Designer.cs
+++ b/DnDCharCtor.Resources/StringResources.Designer.cs
@@ -358,6 +358,24 @@ namespace DnDCharCtor.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to ~Ability Score.
+        /// </summary>
+        public static string Character_Properties_AbilityScore {
+            get {
+                return ResourceManager.GetString("Character_Properties_AbilityScore", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ~Stat Modifier.
+        /// </summary>
+        public static string Character_Properties_StatModifier {
+            get {
+                return ResourceManager.GetString("Character_Properties_StatModifier", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ~Rescue dices.
         /// </summary>
         public static string Character_RescueDices {
@@ -849,15 +867,6 @@ namespace DnDCharCtor.Resources {
         public static string Settings_ThemeSettings {
             get {
                 return ResourceManager.GetString("Settings_ThemeSettings", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to ~Stat Modifier.
-        /// </summary>
-        public static string Stat_Modifier {
-            get {
-                return ResourceManager.GetString("Stat_Modifier", resourceCulture);
             }
         }
         

--- a/DnDCharCtor.Resources/StringResources.de-DE.resx
+++ b/DnDCharCtor.Resources/StringResources.de-DE.resx
@@ -405,7 +405,10 @@
   <data name="CharacterEditor_Skills_Edit" xml:space="preserve">
     <value>Bearbeite Fertigkeiten</value>
   </data>
-  <data name="Stat_Modifier" xml:space="preserve">
+  <data name="Character_Properties_StatModifier" xml:space="preserve">
     <value>Status-Modifikator</value>
+  </data>
+  <data name="Character_Properties_AbilityScore" xml:space="preserve">
+    <value>Fähigkeits-Wert</value>
   </data>
 </root>

--- a/DnDCharCtor.Resources/StringResources.en-US.resx
+++ b/DnDCharCtor.Resources/StringResources.en-US.resx
@@ -405,7 +405,10 @@
   <data name="CharacterEditor_Skills_Edit" xml:space="preserve">
     <value>Edit skills</value>
   </data>
-  <data name="Stat_Modifier" xml:space="preserve">
+  <data name="Character_Properties_StatModifier" xml:space="preserve">
     <value>Stat Modifier</value>
+  </data>
+  <data name="Character_Properties_AbilityScore" xml:space="preserve">
+    <value>Ability Score</value>
   </data>
 </root>

--- a/DnDCharCtor.Resources/StringResources.resx
+++ b/DnDCharCtor.Resources/StringResources.resx
@@ -405,7 +405,10 @@
   <data name="CharacterEditor_Skills_Edit" xml:space="preserve">
     <value>~Edit skills</value>
   </data>
-  <data name="Stat_Modifier" xml:space="preserve">
+  <data name="Character_Properties_StatModifier" xml:space="preserve">
     <value>~Stat Modifier</value>
+  </data>
+  <data name="Character_Properties_AbilityScore" xml:space="preserve">
+    <value>~Ability Score</value>
   </data>
 </root>

--- a/DnDCharCtor/DnDCharCtor.Ui/Components/Cards/PropertiesCard.razor
+++ b/DnDCharCtor/DnDCharCtor.Ui/Components/Cards/PropertiesCard.razor
@@ -2,25 +2,25 @@
 
 <EditableCardBase Title="@StringResources.Character_Properties" EditButtonText="@EditButtonText" EditButtonIcon="@EditButtonIcon" EditButtonCallback="EditAsync" CardClickCallback="EditAsync" HasValidationErrors="@(ViewModel.HasValidationErrors)">
     <br />
-    <div><strong>@StringResources.Character_Strength:</strong> @ViewModel.Strength </div>
-    <div><strong>@StringResources.Character_Strength (@StringResources.Stat_Modifier):</strong> @(ViewModel.Strength.ToInt() is int strength ? DndRulesService.CalculateStatModifier(strength) : string.Empty) </div>
+    <div><strong>@StringResources.Character_Strength (@StringResources.Character_Properties_AbilityScore):</strong> @ViewModel.Strength </div>
+    <div><strong>@StringResources.Character_Strength (@StringResources.Character_Properties_StatModifier):</strong> @(ViewModel.Strength.ToInt() is int strength ? DndRulesService.CalculateStatModifier(strength) : string.Empty) </div>
     <br />
-    <div><strong>@StringResources.Character_Skillfulness:</strong> @ViewModel.Skillfulness </div>
-    <div><strong>@StringResources.Character_Skillfulness (@StringResources.Stat_Modifier):</strong> @(ViewModel.Skillfulness.ToInt() is int skillfulness ? DndRulesService.CalculateStatModifier(skillfulness) : string.Empty) </div>
+    <div><strong>@StringResources.Character_Skillfulness (@StringResources.Character_Properties_AbilityScore):</strong> @ViewModel.Skillfulness </div>
+    <div><strong>@StringResources.Character_Skillfulness (@StringResources.Character_Properties_StatModifier):</strong> @(ViewModel.Skillfulness.ToInt() is int skillfulness ? DndRulesService.CalculateStatModifier(skillfulness) : string.Empty) </div>
     <br />
-    <div><strong>@StringResources.Character_Constitution:</strong> @ViewModel.Constitution </div>
-    <div><strong>@StringResources.Character_Constitution (@StringResources.Stat_Modifier):</strong> @(ViewModel.Constitution.ToInt() is int constitution ? DndRulesService.CalculateStatModifier(constitution) : string.Empty) </div>
+    <div><strong>@StringResources.Character_Constitution (@StringResources.Character_Properties_AbilityScore):</strong> @ViewModel.Constitution </div>
+    <div><strong>@StringResources.Character_Constitution (@StringResources.Character_Properties_StatModifier):</strong> @(ViewModel.Constitution.ToInt() is int constitution ? DndRulesService.CalculateStatModifier(constitution) : string.Empty) </div>
     <br />
-    <div><strong>@StringResources.Character_Intelligence:</strong> @ViewModel.Intelligence </div>
-    <div><strong>@StringResources.Character_Intelligence (@StringResources.Stat_Modifier):</strong> @(ViewModel.Intelligence.ToInt() is int intelligence ? DndRulesService.CalculateStatModifier(intelligence) : string.Empty) </div>
+    <div><strong>@StringResources.Character_Intelligence (@StringResources.Character_Properties_AbilityScore):</strong> @ViewModel.Intelligence </div>
+    <div><strong>@StringResources.Character_Intelligence (@StringResources.Character_Properties_StatModifier):</strong> @(ViewModel.Intelligence.ToInt() is int intelligence ? DndRulesService.CalculateStatModifier(intelligence) : string.Empty) </div>
     <br />
-    <div><strong>@StringResources.Character_Wisdom:</strong> @ViewModel.Wisdom </div>
-    <div><strong>@StringResources.Character_Wisdom (@StringResources.Stat_Modifier):</strong> @(ViewModel.Wisdom.ToInt() is int wisdom ? DndRulesService.CalculateStatModifier(wisdom) : string.Empty) </div>
+    <div><strong>@StringResources.Character_Wisdom (@StringResources.Character_Properties_AbilityScore):</strong> @ViewModel.Wisdom </div>
+    <div><strong>@StringResources.Character_Wisdom (@StringResources.Character_Properties_StatModifier):</strong> @(ViewModel.Wisdom.ToInt() is int wisdom ? DndRulesService.CalculateStatModifier(wisdom) : string.Empty) </div>
     <br />
-    <div><strong>@StringResources.Character_Charisma:</strong> @ViewModel.Charisma </div>
-    <div><strong>@StringResources.Character_Charisma (@StringResources.Stat_Modifier):</strong> @(ViewModel.Charisma.ToInt() is int charisma ? DndRulesService.CalculateStatModifier(charisma) : string.Empty) </div>
+    <div><strong>@StringResources.Character_Charisma (@StringResources.Character_Properties_AbilityScore):</strong> @ViewModel.Charisma </div>
+    <div><strong>@StringResources.Character_Charisma (@StringResources.Character_Properties_StatModifier):</strong> @(ViewModel.Charisma.ToInt() is int charisma ? DndRulesService.CalculateStatModifier(charisma) : string.Empty) </div>
     <br />
-    <div><strong>@StringResources.Character_Inspiration:</strong> @ViewModel.Inspiration </div>
+    <div><strong>@StringResources.Character_Inspiration (@StringResources.Character_Properties_AbilityScore):</strong> @ViewModel.Inspiration </div>
     <br />
     <div><strong>@StringResources.Character_TrainingBonus:</strong> @ViewModel.TrainingBonus </div>
     <br />

--- a/DnDCharCtor/DnDCharCtor.Ui/Components/Dialogs/EditPropertiesDialog.razor
+++ b/DnDCharCtor/DnDCharCtor.Ui/Components/Dialogs/EditPropertiesDialog.razor
@@ -1,34 +1,34 @@
 ﻿@implements IDialogContentComponent<EditDialogParameter<PropertiesViewModel>>
 
 <EditDialogBase Content="@Content">
-    <FluentTextField InputMode="InputMode.Numeric" @bind-Value="Content.ViewModel.Strength" Label="@StringResources.Character_Strength" Immediate="true" Required="true" title="@StringResources.Validation_Tooltip_Required" />
+    <FluentTextField InputMode="InputMode.Numeric" @bind-Value="Content.ViewModel.Strength" Label="@($"{StringResources.Character_Strength} ({StringResources.Character_Properties_AbilityScore})")" Immediate="true" Required="true" title="@StringResources.Validation_Tooltip_Required" />
     <ValidationMessage For="@(() => Content.ViewModel.Strength)" />
-    <div>@StringResources.Character_Strength (@StringResources.Stat_Modifier): @(Content.ViewModel.Strength.ToInt() is int strength ? DndRulesService.CalculateStatModifier(strength) : string.Empty) </div>
+    <div>@StringResources.Character_Strength (@StringResources.Character_Properties_StatModifier): @(Content.ViewModel.Strength.ToInt() is int strength ? DndRulesService.CalculateStatModifier(strength) : string.Empty) </div>
     <br />
 
-    <FluentTextField InputMode="InputMode.Numeric" @bind-Value="Content.ViewModel.Skillfulness" Label="@StringResources.Character_Skillfulness" Immediate="true" Required="true" title="@StringResources.Validation_Tooltip_Required" />
+    <FluentTextField InputMode="InputMode.Numeric" @bind-Value="Content.ViewModel.Skillfulness" Label="@($"{StringResources.Character_Skillfulness} ({StringResources.Character_Properties_AbilityScore})")" Immediate="true" Required="true" title="@StringResources.Validation_Tooltip_Required" />
     <ValidationMessage For="@(() => Content.ViewModel.Skillfulness)" />
-    <div>@StringResources.Character_Skillfulness (@StringResources.Stat_Modifier): @(Content.ViewModel.Skillfulness.ToInt() is int skillfulness ? DndRulesService.CalculateStatModifier(skillfulness) : string.Empty) </div>
+    <div>@StringResources.Character_Skillfulness (@StringResources.Character_Properties_StatModifier): @(Content.ViewModel.Skillfulness.ToInt() is int skillfulness ? DndRulesService.CalculateStatModifier(skillfulness) : string.Empty) </div>
     <br />
 
-    <FluentTextField InputMode="InputMode.Numeric" @bind-Value="Content.ViewModel.Constitution" Label="@StringResources.Character_Constitution" Immediate="true" Required="true" title="@StringResources.Validation_Tooltip_Required" />
+    <FluentTextField InputMode="InputMode.Numeric" @bind-Value="Content.ViewModel.Constitution" Label="@($"{StringResources.Character_Constitution} ({StringResources.Character_Properties_AbilityScore})")" Immediate="true" Required="true" title="@StringResources.Validation_Tooltip_Required" />
     <ValidationMessage For="@(() => Content.ViewModel.Constitution)" />
-    <div>@StringResources.Character_Constitution (@StringResources.Stat_Modifier): @(Content.ViewModel.Constitution.ToInt() is int constitution ? DndRulesService.CalculateStatModifier(constitution) : string.Empty) </div>
+    <div>@StringResources.Character_Constitution (@StringResources.Character_Properties_StatModifier): @(Content.ViewModel.Constitution.ToInt() is int constitution ? DndRulesService.CalculateStatModifier(constitution) : string.Empty) </div>
     <br />
 
-    <FluentTextField InputMode="InputMode.Numeric" @bind-Value="Content.ViewModel.Intelligence" Label="@StringResources.Character_Intelligence" Immediate="true" Required="true" title="@StringResources.Validation_Tooltip_Required" />
+    <FluentTextField InputMode="InputMode.Numeric" @bind-Value="Content.ViewModel.Intelligence" Label="@($"{StringResources.Character_Intelligence} ({StringResources.Character_Properties_AbilityScore})")" Immediate="true" Required="true" title="@StringResources.Validation_Tooltip_Required" />
     <ValidationMessage For="@(() => Content.ViewModel.Intelligence)" />
-    <div>@StringResources.Character_Intelligence (@StringResources.Stat_Modifier): @(Content.ViewModel.Intelligence.ToInt() is int intelligence ? DndRulesService.CalculateStatModifier(intelligence) : string.Empty) </div>
+    <div>@StringResources.Character_Intelligence (@StringResources.Character_Properties_StatModifier): @(Content.ViewModel.Intelligence.ToInt() is int intelligence ? DndRulesService.CalculateStatModifier(intelligence) : string.Empty) </div>
     <br />
 
-    <FluentTextField InputMode="InputMode.Numeric" @bind-Value="Content.ViewModel.Wisdom" Label="@StringResources.Character_Wisdom" Immediate="true" Required="true" title="@StringResources.Validation_Tooltip_Required" />
+    <FluentTextField InputMode="InputMode.Numeric" @bind-Value="Content.ViewModel.Wisdom" Label="@($"{StringResources.Character_Wisdom} ({StringResources.Character_Properties_AbilityScore})")" Immediate="true" Required="true" title="@StringResources.Validation_Tooltip_Required" />
     <ValidationMessage For="@(() => Content.ViewModel.Wisdom)" />
-    <div>@StringResources.Character_Wisdom (@StringResources.Stat_Modifier): @(Content.ViewModel.Wisdom.ToInt() is int wisdom ? DndRulesService.CalculateStatModifier(wisdom) : string.Empty) </div>
+    <div>@StringResources.Character_Wisdom (@StringResources.Character_Properties_StatModifier): @(Content.ViewModel.Wisdom.ToInt() is int wisdom ? DndRulesService.CalculateStatModifier(wisdom) : string.Empty) </div>
     <br />
 
-    <FluentTextField InputMode="InputMode.Numeric" @bind-Value="Content.ViewModel.Charisma" Label="@StringResources.Character_Charisma" Immediate="true" Required="true" title="@StringResources.Validation_Tooltip_Required" />
+    <FluentTextField InputMode="InputMode.Numeric" @bind-Value="Content.ViewModel.Charisma" Label="@($"{StringResources.Character_Charisma} ({StringResources.Character_Properties_AbilityScore})")" Immediate="true" Required="true" title="@StringResources.Validation_Tooltip_Required" />
     <ValidationMessage For="@(() => Content.ViewModel.Charisma)" />
-    <div>@StringResources.Character_Charisma (@StringResources.Stat_Modifier): @(Content.ViewModel.Charisma.ToInt() is int charisma ? DndRulesService.CalculateStatModifier(charisma) : string.Empty) </div>
+    <div>@StringResources.Character_Charisma (@StringResources.Character_Properties_StatModifier): @(Content.ViewModel.Charisma.ToInt() is int charisma ? DndRulesService.CalculateStatModifier(charisma) : string.Empty) </div>
     <br />
 
     <FluentTextField InputMode="InputMode.Numeric" @bind-Value="Content.ViewModel.Inspiration" Label="@StringResources.Character_Inspiration" Immediate="true" Required="true" title="@StringResources.Validation_Tooltip_Required" />


### PR DESCRIPTION
Introduce new localized strings for "Ability Score" and "Stat Modifier" under `Character_Properties` namespace. Replace old `Stat_Modifier` resource with `Character_Properties_StatModifier` in all relevant resource files. Update `PropertiesCard.razor` and `EditPropertiesDialog.razor` to use new localized strings for better clarity and localization.

Added a check in CalculateStatModifier to return 0 for ability
scores less than 1, ensuring proper handling of invalid scores.